### PR TITLE
the iterator of Dopipeline's response is wrong, modify the len

### DIFF
--- a/rediscluster/redishandle.go
+++ b/rediscluster/redishandle.go
@@ -106,7 +106,7 @@ func (self *RedisHandle) DoPipeline(cmds []ClusterTransaction) (reply interface{
 
 	if !wasError {
 		var newErr error
-		for c := 0; c < (len(cmds) - 1); c++ {
+		for c := 0; c < len(cmds); c++ {
 			rets[c], newErr = rc.Receive()
 			if newErr != nil {
 				return rets, newErr


### PR DESCRIPTION
There has an error of redisHandler.DoPipeline:

	if !wasError {
		var newErr error
		for c := 0; c < (len(cmds) -1); c++ {     // should be  c < len(cmds)
			rets[c], newErr = rc.Receive()
			if newErr != nil {
				return rets, newErr
			}
		}
	}

If call DoPipeline([]rediscluster.ClusterTransaction{ZADD}),  (len(cmds) -1) equals 0 , then will not exexute rc.Receive(), so the rets is nil